### PR TITLE
chore: update dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "hex",
  "musig2",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.9.2",
  "secp",
  "serde",
  "serde_cbor",
@@ -225,6 +225,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -312,16 +324,16 @@ dependencies = [
 
 [[package]]
 name = "musig2"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89eb08ce8778538f84198774795f418358360a29841cfea8dbbb28c04d777e2"
+checksum = "1c5ffeab912897e7577287c8f2b4efbc4be24912f77531b45ba4b18c93f8be21"
 dependencies = [
  "base16ct",
  "hmac",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.9.2",
  "secp",
- "secp256k1 0.30.0",
+ "secp256k1 0.31.1",
  "serde",
  "serdect",
  "sha2",
@@ -330,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ppv-lite86"
@@ -362,6 +374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,8 +399,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -393,6 +421,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -416,7 +454,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -445,14 +492,14 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "secp"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ac68feda6cce08c5091b4e87cf93d4b7fa04b4afd9988d4b36121d949f79ec"
+checksum = "0d3b203895e8f18854c828d1cf7e5710683c3abc28d79330fe5ab723ce5b76e1"
 dependencies = [
  "base16ct",
  "once_cell",
- "rand 0.8.5",
- "secp256k1 0.30.0",
+ "rand 0.9.2",
+ "secp256k1 0.31.1",
  "serde",
  "serdect",
  "subtle",
@@ -466,19 +513,19 @@ checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
- "secp256k1-sys",
+ "rand 0.9.2",
+ "secp256k1-sys 0.11.0",
  "serde",
 ]
 
@@ -487,6 +534,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -612,6 +668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +697,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ bitcoin = { version = "0.32.0", default-features = false, features = [
     "serde",
 ] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-musig2 = { version = "0.2.4", default-features = false, features = [
+musig2 = { version = "0.3.1", default-features = false, features = [
     "secp256k1",
     "rand",
     "serde",
 ] }
-rand = { version = "0.8.5", default-features = false }
-secp = { version = "0.5.0", default-features = false, features = ["serde"] }
+rand = { version = "0.9.2", default-features = false }
+secp = { version = "0.6.0", default-features = false, features = ["serde"] }
 serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serdect = { version = "0.3.0", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10.8", default-features = false }

--- a/src/regtest.rs
+++ b/src/regtest.rs
@@ -78,7 +78,7 @@ struct BitcoindSubprocessHandle {
 fn run_bitcoind() -> Option<(BitcoindSubprocessHandle, BitcoinClient)> {
     let dir = TempDir::new("dlctix").expect("error making tempdir");
 
-    let rpc_port: u16 = rand::thread_rng().gen_range(20000..u16::MAX);
+    let rpc_port: u16 = rand::rng().random_range(20000..u16::MAX);
     let p2p_port: u16 = rpc_port + 1;
 
     let child: process::Child = process::Command::new("bitcoind")
@@ -425,7 +425,7 @@ struct SimulationManager {
 
 impl SimulationManager {
     fn new() -> Self {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
 
         // Oracle
         let oracle_seckey = Scalar::random(&mut rng);
@@ -1348,7 +1348,7 @@ fn stress_test() {
             let outcome = Outcome::Attestation(i);
             let payout_map = (0..winners_per_outcome)
                 .map(|_| {
-                    let player_index: PlayerIndex = rng.gen_range(0..n_players);
+                    let player_index: PlayerIndex = rng.random_range(0..n_players);
                     (player_index, 1)
                 })
                 .collect();

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 #[test]
 fn two_player_example() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     // Define the players' secret data. Each player would normally generate
     // and store their own secret key and payout preimage on their own machine.


### PR DESCRIPTION
Updates some deps to the latest version, test are passing

- musig2: 0.2.4 -> 0.3.1
- secp: 0.5.0 -> 0.6.0
- rand: 0.8.5 -> 0.9.2
- Fix deprecation warnings for rand::thread_rng() -> rand::rng()
- Fix deprecation warnings for gen_range() -> random_range()

